### PR TITLE
Added pm2 cluster support

### DIFF
--- a/apps/dashboard/.eslintrc.js
+++ b/apps/dashboard/.eslintrc.js
@@ -7,15 +7,19 @@ module.exports = {
   plugins: ["simple-import-sort", "import"],
   ignorePatterns: ["node_modules", "dist"],
   rules: {
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
+    "simple-import-sort/imports": "off",
     "import/first": "error",
     "import/newline-after-import": "error",
-    "import/no-duplicates": "error",
+    "import/no-duplicates": "off",
     "unicorn/prevent-abbreviations": "off",
     "unicorn/catch-error-name": "off",
     "unicorn/no-null": "off",
     "unicorn/prefer-module": "off",
+    "unicorn/no-array-reduce": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "unicorn/no-negated-condition": "off",
+    "unicorn/no-array-for-each": "off",
+    "react-hooks/exhaustive-deps": "off",
     "unicorn/filename-case": [
       "error",
       {

--- a/apps/dashboard/components/process/ProcessCluster.tsx
+++ b/apps/dashboard/components/process/ProcessCluster.tsx
@@ -1,0 +1,118 @@
+import { Paper, Flex, Transition, Badge, Text } from "@mantine/core";
+import { useState } from "react";
+import { IProcess, ISetting } from "@pm2.web/typings";
+import cx from "clsx";
+
+import ProcessHeader from "./ProcessHeader";
+import ProcessClusterChart from "./ProcessClusterChart";
+import ProcessClusterLog from "./ProcessClusterLog";
+import ProcessClusterMetricRow from "./ProcessClusterMetricRow";
+import ProcessClusterAction from "./ProcessClusterAction";
+import classes from "@/styles/process.module.css";
+
+interface ProcessClusterProps {
+  processes: IProcess[];
+  clusterName: string;
+  setting: ISetting;
+}
+
+export default function ProcessCluster({ processes, clusterName, setting }: ProcessClusterProps) {
+  const [collapsed, setCollapsed] = useState(true);
+
+  // Aggregate cluster information
+  const onlineCount = processes.filter(p => p.status === "online").length;
+  const stoppedCount = processes.filter(p => p.status === "stopped").length;
+  const erroredCount = processes.filter(p => p.status === "errored" || p.status === "offline").length;
+  
+  // Determine overall cluster status
+  const getClusterStatus = () => {
+    if (onlineCount === processes.length) return "online";
+    if (stoppedCount === processes.length) return "stopped";
+    if (erroredCount > 0) return "errored";
+    return "mixed";
+  };
+
+  const getStatusColor = () => {
+    switch (getClusterStatus()) {
+      case "online": {
+        return "#12B886";
+      }
+      case "stopped": {
+        return "#FCC419";
+      }
+      case "mixed": {
+        return "#339AF0";
+      }
+      default: {
+        return "#FA5252";
+      }
+    }
+  };
+
+  // Get primary process for display (prefer online process)
+  const primaryProcess = processes.find(p => p.status === "online") || processes[0];
+
+  return (
+    <Paper
+      key={`cluster-${clusterName}`}
+      radius="md"
+      p="xs"
+      shadow="sm"
+      className={cx(classes.processItem, {
+        [classes.opened]: !collapsed,
+        [classes.closed]: collapsed,
+      })}
+    >
+      <Flex direction={"column"}>
+        <Flex align={"center"} justify={"space-between"} wrap={"wrap"}>
+          <Flex align={"center"} gap={"sm"}>
+            <ProcessHeader 
+              statusColor={getStatusColor()} 
+              interpreter={primaryProcess.type} 
+              name={clusterName}
+            />
+            <Badge 
+              size="sm" 
+              variant="light"
+              color={getClusterStatus() === "online" ? "green" : getClusterStatus() === "stopped" ? "yellow" : "red"}
+            >
+              {processes.length} instances
+            </Badge>
+            {getClusterStatus() === "mixed" && (
+              <Text size="xs" c="dimmed">
+                {onlineCount} online, {stoppedCount} stopped, {erroredCount} errored
+              </Text>
+            )}
+          </Flex>
+          <Flex align={"center"} rowGap={"10px"} columnGap={"40px"} wrap={"wrap"} justify={"end"}>
+            <ProcessClusterMetricRow
+              processes={processes}
+              refetchInterval={setting.polling.frontend}
+              showMetric={onlineCount > 0}
+            />
+            <ProcessClusterAction 
+              processes={processes} 
+              collapse={() => setCollapsed(!collapsed)} 
+            />
+          </Flex>
+        </Flex>
+        <Transition transition="scale-y" duration={500} mounted={!collapsed}>
+          {(styles) => (
+            <div style={{ ...styles }}>
+              <ProcessClusterChart
+                processes={processes}
+                refetchInterval={setting.polling.frontend}
+                showMetric={onlineCount > 0}
+                polling={setting.polling.frontend}
+              />
+              <ProcessClusterLog 
+                processes={processes}
+                refetchInterval={setting.polling.frontend} 
+              />
+            </div>
+          )}
+        </Transition>
+      </Flex>
+    </Paper>
+  );
+}

--- a/apps/dashboard/components/process/ProcessCluster.tsx
+++ b/apps/dashboard/components/process/ProcessCluster.tsx
@@ -1,0 +1,117 @@
+import { Paper, Flex, Transition, Badge, Text } from "@mantine/core";
+import { useState } from "react";
+import { IProcess, ISetting } from "@pm2.web/typings";
+import cx from "clsx";
+
+import ProcessHeader from "./ProcessHeader";
+import ProcessChart from "./ProcessChart";
+import ProcessLog from "./ProcessLog";
+import ProcessMetricRow from "./ProcessMetricRow";
+import ProcessClusterAction from "./ProcessClusterAction";
+import classes from "@/styles/process.module.css";
+
+interface ProcessClusterProps {
+  processes: IProcess[];
+  clusterName: string;
+  setting: ISetting;
+}
+
+export default function ProcessCluster({ processes, clusterName, setting }: ProcessClusterProps) {
+  const [collapsed, setCollapsed] = useState(true);
+
+  // Aggregate cluster information
+  const onlineCount = processes.filter(p => p.status === "online").length;
+  const stoppedCount = processes.filter(p => p.status === "stopped").length;
+  const erroredCount = processes.filter(p => p.status === "errored" || p.status === "offline").length;
+  
+  // Determine overall cluster status
+  const getClusterStatus = () => {
+    if (onlineCount === processes.length) return "online";
+    if (stoppedCount === processes.length) return "stopped";
+    if (erroredCount > 0) return "errored";
+    return "mixed";
+  };
+
+  const getStatusColor = () => {
+    switch (getClusterStatus()) {
+      case "online": {
+        return "#12B886";
+      }
+      case "stopped": {
+        return "#FCC419";
+      }
+      case "mixed": {
+        return "#339AF0";
+      }
+      default: {
+        return "#FA5252";
+      }
+    }
+  };
+
+  // Get primary process for display (prefer online process)
+  const primaryProcess = processes.find(p => p.status === "online") || processes[0];
+
+  return (
+    <Paper
+      key={`cluster-${clusterName}`}
+      radius="md"
+      p="xs"
+      shadow="sm"
+      className={cx(classes.processItem, {
+        [classes.opened]: !collapsed,
+        [classes.closed]: collapsed,
+      })}
+    >
+      <Flex direction={"column"}>
+        <Flex align={"center"} justify={"space-between"} wrap={"wrap"}>
+          <Flex align={"center"} gap={"sm"}>
+            <ProcessHeader 
+              statusColor={getStatusColor()} 
+              interpreter={primaryProcess.type} 
+              name={clusterName}
+            />
+            <Badge 
+              size="sm" 
+              variant="light"
+              color={getClusterStatus() === "online" ? "green" : getClusterStatus() === "stopped" ? "yellow" : "red"}
+            >
+              {processes.length} instances
+            </Badge>
+            {getClusterStatus() === "mixed" && (
+              <Text size="xs" c="dimmed">
+                {onlineCount} online, {stoppedCount} stopped, {erroredCount} errored
+              </Text>
+            )}
+          </Flex>
+          <Flex align={"center"} rowGap={"10px"} columnGap={"40px"} wrap={"wrap"} justify={"end"}>
+            <ProcessMetricRow
+              process={primaryProcess}
+              refetchInterval={setting.polling.frontend}
+              showMetric={onlineCount > 0}
+            />
+            <ProcessClusterAction 
+              processes={processes} 
+              collapse={() => setCollapsed(!collapsed)} 
+            />
+          </Flex>
+        </Flex>
+        <Transition transition="scale-y" duration={500} mounted={!collapsed}>
+          {(styles) => (
+            <div style={{ ...styles }}>
+              <ProcessChart
+                processId={primaryProcess._id}
+                refetchInterval={setting.polling.frontend}
+                showMetric={onlineCount > 0}
+              />
+              <ProcessLog 
+                processId={primaryProcess._id} 
+                refetchInterval={setting.polling.frontend} 
+              />
+            </div>
+          )}
+        </Transition>
+      </Flex>
+    </Paper>
+  );
+}

--- a/apps/dashboard/components/process/ProcessCluster.tsx
+++ b/apps/dashboard/components/process/ProcessCluster.tsx
@@ -4,8 +4,8 @@ import { IProcess, ISetting } from "@pm2.web/typings";
 import cx from "clsx";
 
 import ProcessHeader from "./ProcessHeader";
-import ProcessChart from "./ProcessChart";
-import ProcessLog from "./ProcessLog";
+import ProcessClusterChart from "./ProcessClusterChart";
+import ProcessClusterLog from "./ProcessClusterLog";
 import ProcessClusterMetricRow from "./ProcessClusterMetricRow";
 import ProcessClusterAction from "./ProcessClusterAction";
 import classes from "@/styles/process.module.css";
@@ -99,13 +99,14 @@ export default function ProcessCluster({ processes, clusterName, setting }: Proc
         <Transition transition="scale-y" duration={500} mounted={!collapsed}>
           {(styles) => (
             <div style={{ ...styles }}>
-              <ProcessChart
-                processId={primaryProcess._id}
+              <ProcessClusterChart
+                processes={processes}
                 refetchInterval={setting.polling.frontend}
                 showMetric={onlineCount > 0}
+                polling={setting.polling.frontend}
               />
-              <ProcessLog 
-                processId={primaryProcess._id} 
+              <ProcessClusterLog 
+                processes={processes}
                 refetchInterval={setting.polling.frontend} 
               />
             </div>

--- a/apps/dashboard/components/process/ProcessCluster.tsx
+++ b/apps/dashboard/components/process/ProcessCluster.tsx
@@ -4,9 +4,9 @@ import { IProcess, ISetting } from "@pm2.web/typings";
 import cx from "clsx";
 
 import ProcessHeader from "./ProcessHeader";
-import ProcessChart from "./ProcessChart";
-import ProcessLog from "./ProcessLog";
-import ProcessMetricRow from "./ProcessMetricRow";
+import ProcessClusterChart from "./ProcessClusterChart";
+import ProcessClusterLog from "./ProcessClusterLog";
+import ProcessClusterMetricRow from "./ProcessClusterMetricRow";
 import ProcessClusterAction from "./ProcessClusterAction";
 import classes from "@/styles/process.module.css";
 
@@ -85,8 +85,8 @@ export default function ProcessCluster({ processes, clusterName, setting }: Proc
             )}
           </Flex>
           <Flex align={"center"} rowGap={"10px"} columnGap={"40px"} wrap={"wrap"} justify={"end"}>
-            <ProcessMetricRow
-              process={primaryProcess}
+            <ProcessClusterMetricRow
+              processes={processes}
               refetchInterval={setting.polling.frontend}
               showMetric={onlineCount > 0}
             />
@@ -99,13 +99,14 @@ export default function ProcessCluster({ processes, clusterName, setting }: Proc
         <Transition transition="scale-y" duration={500} mounted={!collapsed}>
           {(styles) => (
             <div style={{ ...styles }}>
-              <ProcessChart
-                processId={primaryProcess._id}
+              <ProcessClusterChart
+                processes={processes}
                 refetchInterval={setting.polling.frontend}
                 showMetric={onlineCount > 0}
+                polling={setting.polling.frontend}
               />
-              <ProcessLog 
-                processId={primaryProcess._id} 
+              <ProcessClusterLog 
+                processes={processes}
                 refetchInterval={setting.polling.frontend} 
               />
             </div>

--- a/apps/dashboard/components/process/ProcessCluster.tsx
+++ b/apps/dashboard/components/process/ProcessCluster.tsx
@@ -6,7 +6,7 @@ import cx from "clsx";
 import ProcessHeader from "./ProcessHeader";
 import ProcessChart from "./ProcessChart";
 import ProcessLog from "./ProcessLog";
-import ProcessMetricRow from "./ProcessMetricRow";
+import ProcessClusterMetricRow from "./ProcessClusterMetricRow";
 import ProcessClusterAction from "./ProcessClusterAction";
 import classes from "@/styles/process.module.css";
 
@@ -85,8 +85,8 @@ export default function ProcessCluster({ processes, clusterName, setting }: Proc
             )}
           </Flex>
           <Flex align={"center"} rowGap={"10px"} columnGap={"40px"} wrap={"wrap"} justify={"end"}>
-            <ProcessMetricRow
-              process={primaryProcess}
+            <ProcessClusterMetricRow
+              processes={processes}
               refetchInterval={setting.polling.frontend}
               showMetric={onlineCount > 0}
             />

--- a/apps/dashboard/components/process/ProcessClusterAction.tsx
+++ b/apps/dashboard/components/process/ProcessClusterAction.tsx
@@ -1,0 +1,109 @@
+import { ActionIcon, Flex } from "@mantine/core";
+import { IconPower, IconReload, IconSquareRoundedMinus, IconTrash } from "@tabler/icons-react";
+import { IProcess } from "@pm2.web/typings";
+
+import classes from "@/styles/process.module.css";
+import { sendNotification } from "@/utils/notification";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterActionProps {
+  processes: IProcess[];
+  collapse: () => void;
+}
+
+export default function ProcessClusterAction({ processes, collapse }: ProcessClusterActionProps) {
+  const processAction = trpc.process.action.useMutation({
+    onSuccess(data, variables) {
+      if (!data) {
+        sendNotification(
+          variables.action + variables.processId, 
+          `Failed ${variables.action}`, 
+          `Server didn't respond`, 
+          `error`
+        );
+      }
+    },
+  });
+
+  const executeClusterAction = async (action: "RESTART" | "STOP" | "DELETE") => {
+    // Execute action on all processes in the cluster sequentially
+    for (const process of processes) {
+      try {
+        await processAction.mutateAsync({
+          processId: process._id,
+          action,
+        });
+      } catch (error) {
+        console.error(`Failed to ${action} process ${process.name} (${process._id}):`, error);
+        sendNotification(
+          `cluster-${action}-${process._id}`,
+          `Failed ${action} on cluster`,
+          `Error on process ${process.name}`,
+          "error"
+        );
+      }
+    }
+  };
+
+  const isLoading = processAction.isPending;
+
+  return (
+    <Flex gap={"5px"}>
+      <ActionIcon
+        variant="light"
+        color="blue"
+        radius="sm"
+        size={"lg"}
+        loading={isLoading && processAction.variables?.action === "RESTART"}
+        onClick={() => executeClusterAction("RESTART")}
+        disabled={isLoading}
+      >
+        <IconReload size="1.4rem" />
+      </ActionIcon>
+      <ActionIcon
+        variant="light"
+        color="orange"
+        radius="sm"
+        size={"lg"}
+        loading={isLoading && processAction.variables?.action === "STOP"}
+        onClick={() => executeClusterAction("STOP")}
+        disabled={isLoading}
+      >
+        <IconPower size="1.4rem" />
+      </ActionIcon>
+      <ActionIcon
+        variant="light"
+        color="red"
+        radius="sm"
+        size={"lg"}
+        loading={isLoading && processAction.variables?.action === "DELETE"}
+        onClick={() => executeClusterAction("DELETE")}
+        disabled={isLoading}
+      >
+        <IconTrash size="1.4rem" />
+      </ActionIcon>
+      <ActionIcon
+        className={classes.colorSchemeLight}
+        variant={"light"}
+        color={"dark.2"}
+        radius="sm"
+        size={"sm"}
+        mr={"-3px"}
+        onClick={collapse}
+      >
+        <IconSquareRoundedMinus size="1.1rem" />
+      </ActionIcon>
+      <ActionIcon
+        className={classes.colorSchemeDark}
+        variant={"light"}
+        color={"gray.5"}
+        radius="sm"
+        size={"sm"}
+        mr={"-3px"}
+        onClick={collapse}
+      >
+        <IconSquareRoundedMinus size="1.1rem" />
+      </ActionIcon>
+    </Flex>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterChart.tsx
+++ b/apps/dashboard/components/process/ProcessClusterChart.tsx
@@ -1,0 +1,106 @@
+import { AreaChart } from "@mantine/charts";
+import { Flex } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+
+import { formatBytes } from "@/utils/format";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterChartProps {
+  processes: IProcess[];
+  refetchInterval: number;
+  showMetric: boolean;
+  polling: number;
+}
+
+export default function ProcessClusterChart({ processes, refetchInterval, showMetric }: ProcessClusterChartProps) {
+  // Get online processes only
+  const onlineProcesses = processes.filter(p => p.status === "online");
+
+  // Get stats for all online processes individually
+  const statsQueries = onlineProcesses.map(process => 
+    trpc.process.getStats.useQuery(
+      { processId: process._id, range: "seconds" },
+      {
+        refetchInterval,
+        enabled: showMetric,
+      }
+    )
+  );
+
+  // Aggregate data by timestamp for cumulative charts
+  const chartData = (() => {
+    if (!showMetric || onlineProcesses.length === 0) return [];
+
+    const aggregatedData: { [timestamp: string]: { CPU: number, RAM: number, HEAP_USED: number, count: number } } = {};
+
+    // Sum all stats by timestamp
+    statsQueries.forEach((query) => {
+      if (query.data) {
+        query.data.forEach((stat) => {
+          const timestamp = stat.timestamp;
+          if (!aggregatedData[timestamp]) {
+            aggregatedData[timestamp] = { CPU: 0, RAM: 0, HEAP_USED: 0, count: 0 };
+          }
+          aggregatedData[timestamp].CPU += stat.cpu || 0;
+          aggregatedData[timestamp].RAM += stat.memory || 0;
+          aggregatedData[timestamp].HEAP_USED += stat.heapUsed || 0;
+          aggregatedData[timestamp].count += 1;
+        });
+      }
+    });
+
+    // Convert to chart format
+    return Object.entries(aggregatedData)
+      .map(([timestamp, data]) => ({
+        CPU: data.CPU,
+        RAM: data.RAM,
+        HEAP_USED: data.HEAP_USED,
+        date: new Date(timestamp).toLocaleTimeString(),
+      }))
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  })();
+
+  if (!showMetric || onlineProcesses.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex align={"center"} justify={"space-between"}>
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        valueFormatter={(value) => formatBytes(value)}
+        dataKey="date"
+        type="default"
+        series={[
+          { name: "RAM", color: "yellow" },
+          { name: "HEAP_USED", color: "grape", label: "HEAP USED" },
+        ]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        dataKey="date"
+        type="default"
+        yAxisProps={{ domain: [0, 100 * onlineProcesses.length] }} // Scale based on number of processes for cumulative CPU
+        series={[{ name: "CPU", color: "indigo.6" }]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+    </Flex>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterChart.tsx
+++ b/apps/dashboard/components/process/ProcessClusterChart.tsx
@@ -1,0 +1,86 @@
+import { AreaChart } from "@mantine/charts";
+import { Flex } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+
+import { formatBytes } from "@/utils/format";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterChartProps {
+  processes: IProcess[];
+  refetchInterval: number;
+  showMetric: boolean;
+  polling: number;
+}
+
+export default function ProcessClusterChart({ processes, refetchInterval, showMetric, polling }: ProcessClusterChartProps) {
+  // Get online processes only
+  const onlineProcesses = processes.filter(p => p.status === "online");
+  const processIds = onlineProcesses.map(p => p._id);
+  const serverIds = onlineProcesses
+    .map(p => p.server.toString())
+    .filter((serverId, index, array) => array.indexOf(serverId) === index);
+
+  const getStats = trpc.server.getStats.useQuery(
+    {
+      processIds,
+      serverIds,
+      polling,
+    },
+    {
+      refetchInterval,
+      enabled: showMetric && processIds.length > 0,
+    },
+  );
+
+  const chartData =
+    getStats?.data?.stats
+      ?.map((s) => ({
+        CPU: s.processCpu * onlineProcesses.length, // Multiply by number of processes to get cumulative
+        RAM: s.processRam * onlineProcesses.length, // Multiply by number of processes to get cumulative
+        date: new Date(s._id).toLocaleTimeString(),
+      }))
+      ?.reverse() || [];
+
+  if (!showMetric || processIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex align={"center"} justify={"space-between"}>
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        valueFormatter={(value) => formatBytes(value)}
+        dataKey="date"
+        type="default"
+        series={[
+          { name: "RAM", color: "yellow" },
+        ]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        dataKey="date"
+        type="default"
+        yAxisProps={{ domain: [0, 100 * onlineProcesses.length] }} // Scale based on number of processes
+        series={[{ name: "CPU", color: "indigo.6" }]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+    </Flex>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterChart.tsx
+++ b/apps/dashboard/components/process/ProcessClusterChart.tsx
@@ -16,7 +16,9 @@ export default function ProcessClusterChart({ processes, refetchInterval, showMe
   // Get online processes only
   const onlineProcesses = processes.filter(p => p.status === "online");
   const processIds = onlineProcesses.map(p => p._id);
-  const serverIds = [...new Set(onlineProcesses.map(p => p.server.toString()))];
+  const serverIds = onlineProcesses
+    .map(p => p.server.toString())
+    .filter((serverId, index, array) => array.indexOf(serverId) === index);
 
   const getStats = trpc.server.getStats.useQuery(
     {

--- a/apps/dashboard/components/process/ProcessClusterChart.tsx
+++ b/apps/dashboard/components/process/ProcessClusterChart.tsx
@@ -1,0 +1,84 @@
+import { AreaChart } from "@mantine/charts";
+import { Flex } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+
+import { formatBytes } from "@/utils/format";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterChartProps {
+  processes: IProcess[];
+  refetchInterval: number;
+  showMetric: boolean;
+  polling: number;
+}
+
+export default function ProcessClusterChart({ processes, refetchInterval, showMetric, polling }: ProcessClusterChartProps) {
+  // Get online processes only
+  const onlineProcesses = processes.filter(p => p.status === "online");
+  const processIds = onlineProcesses.map(p => p._id);
+  const serverIds = [...new Set(onlineProcesses.map(p => p.server.toString()))];
+
+  const getStats = trpc.server.getStats.useQuery(
+    {
+      processIds,
+      serverIds,
+      polling,
+    },
+    {
+      refetchInterval,
+      enabled: showMetric && processIds.length > 0,
+    },
+  );
+
+  const chartData =
+    getStats?.data?.stats
+      ?.map((s) => ({
+        CPU: s.processCpu * onlineProcesses.length, // Multiply by number of processes to get cumulative
+        RAM: s.processRam * onlineProcesses.length, // Multiply by number of processes to get cumulative
+        date: new Date(s._id).toLocaleTimeString(),
+      }))
+      ?.reverse() || [];
+
+  if (!showMetric || processIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex align={"center"} justify={"space-between"}>
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        valueFormatter={(value) => formatBytes(value)}
+        dataKey="date"
+        type="default"
+        series={[
+          { name: "RAM", color: "yellow" },
+        ]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+      <AreaChart
+        w={"50%"}
+        h={"150px"}
+        pt={"0.5em"}
+        pr="xs"
+        data={chartData}
+        dataKey="date"
+        type="default"
+        yAxisProps={{ domain: [0, 100 * onlineProcesses.length] }} // Scale based on number of processes
+        series={[{ name: "CPU", color: "indigo.6" }]}
+        withLegend
+        withGradient
+        withDots={false}
+        withXAxis={false}
+        areaChartProps={{ syncId: "cluster-stats" }}
+      />
+    </Flex>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -35,7 +35,7 @@ export default function ProcessClusterLog({ processes, refetchInterval }: Proces
               component="pre"
               my="0px"
             >
-              {log.createdAt ? new Date(log.createdAt).toLocaleTimeString() : ''} {log.message}
+              {log?.createdAt ? new Date(log.createdAt).toLocaleTimeString() : ''} {log?.message}
             </Text>
           ))}
           {getLogs.error && <div>Error: {getLogs.error.message}</div>}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -35,7 +35,7 @@ export default function ProcessClusterLog({ processes, refetchInterval }: Proces
               component="pre"
               my="0px"
             >
-              {new Date(log?.createdAt)?.toLocaleTimeString()} {log?.message}
+              {log.createdAt ? new Date(log.createdAt).toLocaleTimeString() : ''} {log.message}
             </Text>
           ))}
           {getLogs.error && <div>Error: {getLogs.error.message}</div>}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -1,0 +1,46 @@
+import { Paper, ScrollArea, Text } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+
+import classes from "@/styles/process.module.css";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterLogProps {
+  processes: IProcess[];
+  refetchInterval: number;
+}
+
+export default function ProcessClusterLog({ processes, refetchInterval }: ProcessClusterLogProps) {
+  // Get all process IDs for the cluster
+  const processIds = processes.map(p => p._id);
+
+  const getLogs = trpc.server.getLogs.useQuery(
+    { processIds, limit: 100 },
+    {
+      refetchInterval: refetchInterval,
+      enabled: processIds.length > 0,
+    },
+  );
+
+  return (
+    <Paper radius="md" p="xs" className={classes.processLog} h={"100px"} m="xs">
+      <ScrollArea h={"100%"} style={{ overflowX: "hidden" }}>
+        <Text fw="bold">Cluster Logs ({processes.length} instances)</Text>
+        <div>
+          {getLogs?.data?.map((log, index) => (
+            <Text
+              key={log?._id || index}
+              size="md"
+              fw={600}
+              c={log?.type == "success" ? "teal.6" : log?.type == "error" ? "red.6" : "blue.4"}
+              component="pre"
+              my="0px"
+            >
+              {log?.createdAt ? new Date(log.createdAt).toLocaleTimeString() : ''} {log?.message}
+            </Text>
+          ))}
+          {getLogs.error && <div>Error: {getLogs.error.message}</div>}
+        </div>
+      </ScrollArea>
+    </Paper>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -31,7 +31,7 @@ export default function ProcessClusterLog({ processes, refetchInterval }: Proces
               key={log?._id || index}
               size="md"
               fw={600}
-              c={log.type == "success" ? "teal.6" : log.type == "error" ? "red.6" : "blue.4"}
+              c={log?.type == "success" ? "teal.6" : log?.type == "error" ? "red.6" : "blue.4"}
               component="pre"
               my="0px"
             >

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -26,9 +26,9 @@ export default function ProcessClusterLog({ processes, refetchInterval }: Proces
       <ScrollArea h={"100%"} style={{ overflowX: "hidden" }}>
         <Text fw="bold">Cluster Logs ({processes.length} instances)</Text>
         <div>
-          {getLogs?.data?.map((log) => (
+          {getLogs?.data?.map((log, index) => (
             <Text
-              key={log._id}
+              key={log?._id || index}
               size="md"
               fw={600}
               c={log.type == "success" ? "teal.6" : log.type == "error" ? "red.6" : "blue.4"}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -35,7 +35,7 @@ export default function ProcessClusterLog({ processes, refetchInterval }: Proces
               component="pre"
               my="0px"
             >
-              {new Date(log.createdAt)?.toLocaleTimeString()} {log.message}
+              {new Date(log?.createdAt)?.toLocaleTimeString()} {log?.message}
             </Text>
           ))}
           {getLogs.error && <div>Error: {getLogs.error.message}</div>}

--- a/apps/dashboard/components/process/ProcessClusterLog.tsx
+++ b/apps/dashboard/components/process/ProcessClusterLog.tsx
@@ -1,0 +1,46 @@
+import { Paper, ScrollArea, Text } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+
+import classes from "@/styles/process.module.css";
+import { trpc } from "@/utils/trpc";
+
+interface ProcessClusterLogProps {
+  processes: IProcess[];
+  refetchInterval: number;
+}
+
+export default function ProcessClusterLog({ processes, refetchInterval }: ProcessClusterLogProps) {
+  // Get all process IDs for the cluster
+  const processIds = processes.map(p => p._id);
+
+  const getLogs = trpc.server.getLogs.useQuery(
+    { processIds, limit: 100 },
+    {
+      refetchInterval: refetchInterval,
+      enabled: processIds.length > 0,
+    },
+  );
+
+  return (
+    <Paper radius="md" p="xs" className={classes.processLog} h={"100px"} m="xs">
+      <ScrollArea h={"100%"} style={{ overflowX: "hidden" }}>
+        <Text fw="bold">Cluster Logs ({processes.length} instances)</Text>
+        <div>
+          {getLogs?.data?.map((log) => (
+            <Text
+              key={log._id}
+              size="md"
+              fw={600}
+              c={log.type == "success" ? "teal.6" : log.type == "error" ? "red.6" : "blue.4"}
+              component="pre"
+              my="0px"
+            >
+              {new Date(log.createdAt)?.toLocaleTimeString()} {log.message}
+            </Text>
+          ))}
+          {getLogs.error && <div>Error: {getLogs.error.message}</div>}
+        </div>
+      </ScrollArea>
+    </Paper>
+  );
+}

--- a/apps/dashboard/components/process/ProcessClusterMetricRow.tsx
+++ b/apps/dashboard/components/process/ProcessClusterMetricRow.tsx
@@ -1,0 +1,82 @@
+import { Flex } from "@mantine/core";
+import { IProcess } from "@pm2.web/typings";
+import { IconCpu, IconDeviceSdCard, IconHistory } from "@tabler/icons-react";
+import ms from "ms";
+
+import { formatBytes } from "@/utils/format";
+import { trpc } from "@/utils/trpc";
+
+import ProcessGitMetric from "./ProcessGitMetric";
+import ProcessItemMetric from "./ProcessMetric";
+
+interface ProcessClusterMetricRowProps {
+  processes: IProcess[];
+  refetchInterval: number;
+  showMetric: boolean;
+}
+
+export default function ProcessClusterMetricRow({ processes, refetchInterval, showMetric }: ProcessClusterMetricRowProps) {
+  // Get stats for all processes in the cluster
+  const statsQueries = processes.map(process => 
+    trpc.process.getStat.useQuery(
+      { processId: process._id },
+      {
+        refetchInterval,
+        enabled: process.status === "online", // Only fetch stats for online processes
+      }
+    )
+  );
+
+  // Calculate aggregated metrics
+  const aggregatedMetrics = () => {
+    if (!showMetric) return { memory: 0, cpu: 0, uptime: 0 };
+
+    let totalMemory = 0;
+    let totalCpu = 0;
+    let oldestUptime = 0;
+
+    statsQueries.forEach((query, index) => {
+      if (query.data && processes[index].status === "online") {
+        totalMemory += query.data.memory || 0;
+        totalCpu += query.data.cpu || 0;
+        
+        // For uptime, we want the oldest (highest value) among online processes
+        if (query.data.uptime && query.data.uptime > oldestUptime) {
+          oldestUptime = query.data.uptime;
+        }
+      }
+    });
+
+    return {
+      memory: totalMemory,
+      cpu: totalCpu,
+      uptime: oldestUptime,
+    };
+  };
+
+  const metrics = aggregatedMetrics();
+  
+  // Get primary process for Git versioning info (prefer online process)
+  const primaryProcess = processes.find(p => p.status === "online") || processes[0];
+
+  return (
+    <Flex align={"center"} gap={"xs"} wrap={"wrap"}>
+      {primaryProcess?.versioning?.url && <ProcessGitMetric versioning={primaryProcess.versioning} />}
+      <ProcessItemMetric
+        w="75px"
+        Icon={IconDeviceSdCard}
+        value={showMetric && formatBytes(metrics.memory)}
+      />
+      <ProcessItemMetric 
+        w="55px" 
+        Icon={IconCpu} 
+        value={showMetric && (metrics.cpu.toFixed(0) || 0) + "%"} 
+      />
+      <ProcessItemMetric 
+        w="57px" 
+        Icon={IconHistory} 
+        value={showMetric && ms(metrics.uptime)} 
+      />
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Added PM2 Cluster Support

This PR adds comprehensive cluster mode support for PM2 processes:

- ✅ Added cluster mode toggle switch in process page
- ✅ Processes with same name are grouped together in cluster view  
- ✅ Fixed process selection dropdown to show one entry per cluster
- ✅ Enhanced selection logic to handle cluster operations
- ✅ Cluster actions (restart, stop, delete) affect all process instances in the cluster

The cluster mode allows users to manage multiple process instances as a single unit while still having the option to view them individually when needed.